### PR TITLE
Adding vit matte model from hugging face for matte result testing

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -41,3 +41,7 @@ SENTRY_DSN = os.getenv("SENTRY_DSN")
 
 # WANDB
 WANDB_API_KEY = os.getenv("WANDB_API_KEY")
+
+# VIT MATTE HF
+VIT_MATTE_HF_MODEL_NAME = "hustvl/vitmatte-small-composition-1k"
+DIRECTORY_TO_SAVE_VIT_MATTE_HF = "./vit_matte_hf"

--- a/predict.py
+++ b/predict.py
@@ -93,9 +93,9 @@ class Predictor(BasePredictor):
 
             # write trimap to disk for debugging
             cv2.imwrite("trimap.png", new_image)
-            log_results_to_wandb("Image", self.image_path)
-            log_results_to_wandb("Segmentation Mask", self.mask_path)
-            log_results_to_wandb("Trimap", self.trimap_path)
+            # log_results_to_wandb("Image", self.image_path)
+            # log_results_to_wandb("Segmentation Mask", self.mask_path)
+            # log_results_to_wandb("Trimap", self.trimap_path)
             vit_matte_and_skin_cut_matte = SkinSegmentVitMatte().generate_modified_matted_results(image,
                                                                                                   self.trimap_path)
             print("vit matte and skin cut matte is ", vit_matte_and_skin_cut_matte)
@@ -111,18 +111,18 @@ class Predictor(BasePredictor):
                 distance = vit_matte_and_skin_cut_matte["distance"]
                 edge_less_no_mask_path = vit_matte_and_skin_cut_matte["edge_less_no_mask"]
 
-                log_results_to_wandb("VIT Matte Alpha Output", output_from_vit_model)
-                log_results_to_wandb("VIT Matte cutout Output",
-                                     vit_matte_and_skin_cut_matte["vit_matte_cutout_image"])
-                log_results_to_wandb("Skin Cut Model Output",
-                                     vit_matte_and_skin_cut_matte["skin_cut_output"])
-                log_results_to_wandb("Final Modified Mask", output_from_modifier_model)
+                # log_results_to_wandb("VIT Matte Alpha Output", output_from_vit_model)
+                # log_results_to_wandb("VIT Matte cutout Output",
+                #                      vit_matte_and_skin_cut_matte["vit_matte_cutout_image"])
+                # log_results_to_wandb("Skin Cut Model Output",
+                #                      vit_matte_and_skin_cut_matte["skin_cut_output"])
+                # log_results_to_wandb("Final Modified Mask", output_from_modifier_model)
                 image_overlay_dir = os.path.join(DIRECTORY_TO_SAVE_IMAGE_OVERLAY, "overlay.png")
                 image_overlay = overlay_final_mask_in_black_background(self.image_path,
                                                                        vit_matte_and_skin_cut_matte["non_converted_final_mask"],
                                                                        image_overlay_dir)
-                if image_overlay["success"]:
-                    log_results_to_wandb("Image Overlay", image_overlay)
+                # if image_overlay["success"]:
+                    # log_results_to_wandb("Image Overlay", image_overlay)
             else:
                 output_from_vit_model = vit_matte_and_skin_cut_matte["error"]
                 output_from_modifier_model = vit_matte_and_skin_cut_matte["error"]

--- a/prediction_using_vit_and_skin_cut.py
+++ b/prediction_using_vit_and_skin_cut.py
@@ -3,10 +3,11 @@ import os
 import cv2
 import torch.nn as nn
 from constants import VIT_MATTE_MODEL_NAME, THRESHOLD, DIRECTORY_TO_SAVE_VIT_MATTE, \
-    DIRECTORY_TO_SAVE_MODIFIED_MATTE, EMBEDDING_THRESHOLD, MODEL_DIR, DIRECTORY_TO_SAVE_EDGE_LESS_MATTE
+    DIRECTORY_TO_SAVE_MODIFIED_MATTE, EMBEDDING_THRESHOLD, MODEL_DIR, DIRECTORY_TO_SAVE_EDGE_LESS_MATTE, \
+    DIRECTORY_TO_SAVE_VIT_MATTE_HF
 from utils import model_initializer, alpha_matte_inference_from_vision_transformer, \
     selective_search_and_remove_skin_tone, calculate_embeddings_diff_between_two_images, \
-    extra_edge_removal_from_matte_output, convert_greyscale_image_to_transparent
+    extra_edge_removal_from_matte_output, convert_greyscale_image_to_transparent, vit_matte_hugging_face_inference
 import torchvision.models as models
 
 
@@ -21,9 +22,11 @@ class SkinSegmentVitMatte:
         self.embedding_model.eval()
 
     def generate_modified_matted_results(self, input_image, trimap_image):
-        cutout_image_from_vit_matting = alpha_matte_inference_from_vision_transformer(self.vit_matte_model, input_image,
-                                                                                      trimap_image,
-                                                                                      DIRECTORY_TO_SAVE_VIT_MATTE)
+        #cutout_image_from_vit_matting = alpha_matte_inference_from_vision_transformer(self.vit_matte_model, input_image,
+        #                                                                              trimap_image,
+        #                                                                              DIRECTORY_TO_SAVE_VIT_MATTE)
+        cutout_image_from_vit_matting = vit_matte_hugging_face_inference(input_image, trimap_image,
+                                                                         DIRECTORY_TO_SAVE_VIT_MATTE_HF)
         if not cutout_image_from_vit_matting["success"]:
             return {"success": False, "error": f"Vit matting failed due to: {cutout_image_from_vit_matting}"}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ torch
 torchvision
 fairscale
 timm
+transformers==4.41.2
 anyio==4.2.0
 attrs==23.1.0
 certifi==2023.11.17

--- a/utils.py
+++ b/utils.py
@@ -1,18 +1,19 @@
 import os
 import random
 from PIL import Image
+import torch
 import cv2
 import torch
 import sentry_sdk
 import wandb
 import numpy as np
-from PIL import Image
 from os.path import join as opj
 from torchvision.transforms import functional as F
 from detectron2.config import LazyConfig, instantiate
 from detectron2.checkpoint import DetectionCheckpointer
 from constants import HAR_CASCADES_PATH, FACE_SCALE_FACTOR, MIN_NEIGHBOURS, MIN_SIZE, LOWER_SKIN_BOUNDARIES, \
-    UPPER_SKIN_BOUNDARIES, MATRIX_TRANSFORM, NORMALIZE_MEAN, NORMALIZE_STD, SIMILARITY_DIMENSION, SENTRY_DSN
+    UPPER_SKIN_BOUNDARIES, MATRIX_TRANSFORM, NORMALIZE_MEAN, NORMALIZE_STD, SIMILARITY_DIMENSION, SENTRY_DSN, \
+    VIT_MATTE_HF_MODEL_NAME
 
 sentry_sdk.init(
     dsn=SENTRY_DSN,
@@ -104,6 +105,44 @@ def calculate_foreground(input_image, alpha_matte, output_path):
     foreground = foreground.squeeze(0).permute(1, 2, 0).numpy()
     image_cutout = (foreground * 255).astype(np.uint8)
     cv2.imwrite(output_path, image_cutout)
+
+def tensor2pil(t_image: torch.Tensor)  -> Image:
+  return Image.fromarray(np.clip(255.0 * t_image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8))
+
+def RGB2RGBA(image, mask):
+  (R, G, B) = image.convert('RGB').split()
+  return Image.merge('RGBA', (R, G, B, mask.convert('L')))
+
+def vit_matte_hugging_face_inference(image_path, trimap_path, dir_for_vit_matte_hf_matte):
+    from PIL import Image
+    from transformers import VitMatteImageProcessor, VitMatteForImageMatting
+    if not os.path.exists(dir_for_vit_matte_hf_matte):
+        os.mkdir(dir_for_vit_matte_hf_matte)
+    pil_input_image = Image.open(image_path)
+    if pil_input_image.mode != 'RGB':
+        pil_input_image = pil_input_image.convert('RGB')
+    pil_trimap_image = Image.open(trimap_path)
+    if pil_trimap_image.mode != 'L':
+        pil_trimap_image = pil_trimap_image.convert('L')
+    try:
+        vit_matte_model = VitMatteForImageMatting.from_pretrained(VIT_MATTE_HF_MODEL_NAME, local_files_only=False)
+        vit_matte_processor = VitMatteImageProcessor.from_pretrained(VIT_MATTE_HF_MODEL_NAME, local_files_only=False)
+        vit_matte_model_processor = vit_matte_processor(images=pil_input_image, trimaps=pil_trimap_image,
+                                                  return_tensors="pt")
+        with torch.no_grad():
+            predictions = vit_matte_model(**vit_matte_model_processor).alphas
+        mask = tensor2pil(predictions).convert('L')
+        path_to_save_vit_matte_mask = os.path.join(dir_for_vit_matte_hf_matte, "vit_matte_hf.png")
+        mask.save(path_to_save_vit_matte_mask)
+        dir_for_alpha_matte = os.path.join(dir_for_vit_matte_hf_matte, "alpha.png")
+        convert_greyscale_image_to_transparent(path_to_save_vit_matte_mask, dir_for_alpha_matte)
+        dir_for_cutout_image = os.path.join(dir_for_vit_matte_hf_matte, "cutout.png")
+        cutout_image = RGB2RGBA(pil_input_image, mask)
+        cutout_image.save(dir_for_cutout_image)
+        return {"success": True, "vit_matte_output": dir_for_alpha_matte, "cutout_output": dir_for_cutout_image}
+    except Exception as e:
+        raise_sentry_error(e)
+        return {"success": False, "error": f"Problem in hugging face VIT Matte due to : {e}"}
 
 
 def alpha_matte_inference_from_vision_transformer(model, input_image, trimap_image, directory_to_save):

--- a/utils.py
+++ b/utils.py
@@ -351,7 +351,7 @@ def raise_sentry_error(error_message):
 
 def initialize_wandb(product_id):
     experiment_count = random.random()
-    wandb.init(project=f"{product_id}_matte_{experiment_count}", ntags=["Matting_Experiment"])
+    wandb.init(project=f"{product_id}_matte_{experiment_count}")
 
 def log_results_to_wandb(output_image_name, path_of_image):
     wandb.log({f"{output_image_name}": wandb.Image(path_of_image)})


### PR DESCRIPTION
- This PR is undertest, this includes matting test using Hugging face code base of VIT matte and the community fine tuned model vit matte composition 1k
- Test set results : https://huggingface.co/datasets/bahaaltech/Matting-Dataset/tree/main/Replicate_version-02
- Minimal / no change found